### PR TITLE
Изменения лексера Makefile

### DIFF
--- a/Makefile/Makefile.lcf
+++ b/Makefile/Makefile.lcf
@@ -57,14 +57,6 @@ object SyntAnal22: TLibSyntAnalyzer
       Font.Style = []
     end
     item
-      DisplayName = 'Section'
-      Font.Charset = DEFAULT_CHARSET
-      Font.Color = clGreen
-      Font.Height = -13
-      Font.Name = 'Courier New'
-      Font.Style = [fsBold]
-    end
-    item
       DisplayName = 'Label'
       Font.Charset = DEFAULT_CHARSET
       Font.Color = clOlive
@@ -93,7 +85,7 @@ object SyntAnal22: TLibSyntAnalyzer
       DisplayName = 'Param'
       StyleName = 'Param'
       TokenType = 5
-      Expression = '^\x20* \w+ \x20* (?=(=|:=|\+=))  '
+      Expression = '^\x20* [\w-]+ \x20* (?=(=|:{1,3}=|\+=|\?=))  '
       ColumnFrom = 0
       ColumnTo = 0
     end
@@ -109,22 +101,14 @@ object SyntAnal22: TLibSyntAnalyzer
       DisplayName = 'Id'
       StyleName = 'Id'
       TokenType = 2
-      Expression = '[a-z_]\w*'
+      Expression = '[a-zA-Z_-][\w-]*'
       ColumnFrom = 0
       ColumnTo = 0
     end
     item
       DisplayName = 'Value'
       StyleName = 'Value'
-      Expression = '\$\(\w+\) | \$\{\w+\}'
-      ColumnFrom = 0
-      ColumnTo = 0
-    end
-    item
-      DisplayName = 'Section'
-      StyleName = 'Section'
-      TokenType = 7
-      Expression = '\[\w+\]'
+      Expression = '\$\([\w-]+\) | \$\{[\w-]+\}'
       ColumnFrom = 0
       ColumnTo = 0
     end
@@ -154,6 +138,7 @@ object SyntAnal22: TLibSyntAnalyzer
             'ifndef'
             'ifneq'
             'include'
+            '-include'
             'override'
             'private'
             'sinclude'
@@ -209,7 +194,6 @@ object SyntAnal22: TLibSyntAnalyzer
   SampleText.Strings = (
     '# multi-line comment \'
     'end of comment'
-    '[section]'
     '"Test str" ${Test}'
     ''
     'default: all'
@@ -228,7 +212,6 @@ object SyntAnal22: TLibSyntAnalyzer
     'String'
     'Param'
     'Number'
-    'Section'
     'Label')
   Extentions = 
     'mak /makefile /Makefile /makefile.gnu /makefile.gcc /makefile.bo' +


### PR DESCRIPTION
1. В Make разрешен дефис "-" в большинсте мест, где нужен идентификатор (`\w` → `[\w-]`)
2. В GNU make переменные можно определять также с помощью `?=`, `::=`, `:::=`
3. Помимо `include` существует `-include` с дефисом в начале
4. ...Никогда не слышал о существовании [секций] в make и не нашёл про них никакой информации. По-моему, в make такого нет. Поправьте, если ошибаюсь 

Было бы также здорово подсвечивать $(ПЕРЕМЕННЫЕ) внутри "строк", но я не уверен, что это возможно.