### PR TITLE
Fix regex of AHK block comment

### DIFF
--- a/AutoHotkey/AutoHotkey.lcf
+++ b/AutoHotkey/AutoHotkey.lcf
@@ -1,4 +1,4 @@
-object SyntAnal2: TLibSyntAnalyzer
+object SyntAnal1: TLibSyntAnalyzer
   Formats = <
     item
       DisplayName = 'Symbol'
@@ -149,7 +149,7 @@ object SyntAnal2: TLibSyntAnalyzer
       DisplayName = 'Comment2'
       StyleName = 'Comment'
       TokenType = 1
-      Expression = '(?s)^\s*/\*.*?(^\s*\*/|\Z)'
+      Expression = '(?s)^\s*/\*.*?(\*/$|^\s*\*/|\Z)'
       ColumnFrom = 0
       ColumnTo = 0
     end
@@ -1192,7 +1192,14 @@ object SyntAnal2: TLibSyntAnalyzer
     '#!^+&<>*~$Key:Test'
     'MsgBox testing... 20.30 + A_AppData + %2%'
     'FileExist() %VarName% `n'
-    ''
+    '/*'
+    'MsgBox "This line is commented out (disabled)."'
+    'MsgBox "Common mistake:" */ " this does not end the comment."'
+    'MsgBox "This line is commented out."'
+    '*/'
+    'MsgBox "This line is not commented out."'
+    '/* This is also valid, but no other code can share the line. */'
+    'MsgBox "This line is not commented out."'
     'Tray:'
     '{'
     'WinWait, "Test" + 100 + LButton'


### PR DESCRIPTION
Hi, Alexey T,
Thanks your great work on CudaText!

I have found a bug of the AHK lexer, the block comment doesn't work properly

e.g. open the official "ui-dash.ahk" which was provided with the AHK, we got:
![Screenshot 2025-04-25 210232](https://github.com/user-attachments/assets/f6e10c62-eedf-4d66-b2f2-31cc3fccc82a)

According to the [AHK doc](https://www.autohotkey.com/docs/v2/Language.htm#comments):

> Excluding tabs and spaces, /* must appear at the start of the line, while */ **can appear only at the start or end of a line**. It is also valid to omit */, in which case the remainder of the file is commented out.

we should consider the `*/` appear **at the end of the line**, while the original regex only consider at the start of a line.

I have updated the regex and copy the "comment example" from the offical documentation
for test
![Screenshot 2025-04-25 214918](https://github.com/user-attachments/assets/660ce47b-ac6e-43a4-a1e8-73db1eb5d1a3)

Then the block comment works properly

![Screenshot 2025-04-25 210302](https://github.com/user-attachments/assets/858b27ee-6aff-4ace-9460-9ace02b4ba3a)

Please let me know if you have any feedback or suggestions. I’d be happy to make any changes needed. Thank you!

Yours sincerely,
Rumia

