### PR TITLE
Update AWK.lcf

### DIFF
--- a/AWK/AWK.lcf
+++ b/AWK/AWK.lcf
@@ -33,6 +33,14 @@ object SyntAnal4: TLibSyntAnalyzer
       Font.Style = [fsBold]
     end
     item
+      DisplayName = 'Id builtin'
+      Font.Charset = DEFAULT_CHARSET
+      Font.Color = clBlue
+      Font.Height = -13
+      Font.Name = 'Courier New'
+      Font.Style = [fsBold]
+    end
+    item
       DisplayName = 'Id var'
       Font.Charset = DEFAULT_CHARSET
       Font.Color = clGreen
@@ -156,12 +164,49 @@ object SyntAnal4: TLibSyntAnalyzer
             'for'
             'func'
             'function'
+            'getline'
             'if'
             'in'
             'next'
             'nextfile'
+            'print'
+            'printf'
             'return'
             'while')
+          TokenTypes = 4
+        end>
+      HighlightPos = cpBound
+      IgnoreAsParent = False
+    end
+    item
+      DisplayName = 'builtin'
+      StyleName = 'Id builtin'
+      BlockType = btTagDetect
+      ConditionList = <
+        item
+          TagList.Strings = (
+            'atan2'
+            'close'
+            'cos'
+            'exp'
+            'fflush'
+            'gsub'
+            'index'
+            'int'
+            'length'
+            'log'
+            'match'
+            'rand'
+            'sin'
+            'split'
+            'sprintf'
+            'sqrt'
+            'srand'
+            'sub'
+            'substr'
+            'system'
+            'tolower'
+            'toupper')
           TokenTypes = 4
         end>
       HighlightPos = cpBound


### PR DESCRIPTION
add missing keywords and builtin function names, as per the [posix specs](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/awk.html#:~:text=following%20words%20are%20keywords).

before:

<img width="975" height="281" alt="image" src="https://github.com/user-attachments/assets/731a6f99-3c61-48e3-949d-7b555d840546" />


after:

<img width="975" height="274" alt="image" src="https://github.com/user-attachments/assets/5e8fa937-f89a-4b27-b78a-b5cb410d352c" />
